### PR TITLE
Add secondary check for issuer to detect Organization if CN is not available.

### DIFF
--- a/certificate_model.php
+++ b/certificate_model.php
@@ -90,6 +90,8 @@ class Certificate_model extends \Model
                     }
                     if (preg_match('/CN = ([^,|\n]+)/', $parts[3], $matches)) {
                         $this->issuer = $matches[1];
+                    } elseif (preg_match('/O = ([^,|\n]+)/', $parts[3], $matches)) {
+                        $this->issuer = $matches[1];                   
                     } else {
                         $this->issuer = 'Unknown';
                     }


### PR DESCRIPTION
I noticed that the Issuer name of the SCEP cert from the MDM SimpleMDM wasn't being detected correctly due to how the cert issuer information was formatted.  
The current certificate_model expects a CN in but SimpleMDM's issuer is in the format of `issuer= C = US, O = SimpleMDM` so it was resulting as "Unknown" in the MR listing.
This change adds a backup check if the CN isn't detected to check for an Organization value.